### PR TITLE
Fix handling of recursive function via local cache

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,4 +28,11 @@ end
     @test @istypestable(f(3)) == false
 end
 
+@testset "Recursive functions" begin
+    recursive_factorial(x) = x * (x>1 ? recursive_factorial(x-1) : 1)
+    @assert recursive_factorial(10) == factorial(10)
+
+    @test AssertTypeStable.@istypestable recursive_factorial(3)
+end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,4 +35,15 @@ end
     @test AssertTypeStable.@istypestable recursive_factorial(3)
 end
 
+@testset "No methods matching" begin
+    f(x::Integer, y::Integer) = true
+    f(x::Int64, y::Any) = false
+
+    # Calling f(1,2) is ambiguous.
+    @assert (try f(1,2) catch e; e end) isa MethodError
+
+    # So it won't have _any_ methods in @code_typed.
+    @test_logs (:warn, r".*no methods.*") AssertTypeStable.@assert_typestable f(1,2)
+end
+
 end


### PR DESCRIPTION
Keep a cache of results during processing of a single run.

Fixes https://github.com/RelationalAI-oss/AssertTypeStable.jl/issues/1.

Partially fixes https://github.com/RelationalAI-oss/AssertTypeStable.jl/issues/2 as well, since the local cache will prevent exponential blow up. We can consider maintaining the cache between runs as a further optimization.